### PR TITLE
Add support for chroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Send your Kafka offset lags to StatsD.
 kafka-statsd --zookeeper-addrs host1:2181,host2:2181 --statsd-addr=statsd:8125 --statsd-prefix kafka.
 ```
 
+`--zookeeper-addrs` also supports Zookeeper chroots for Kafka metadata that do not reside under the root node, ie. `host1:2181,host2:2181/kafka`.
+
 ## Install
 
 Go get:

--- a/main.go
+++ b/main.go
@@ -33,10 +33,12 @@ func main() {
 	defer stats.Close()
 
 	var zookeeperNodes []string
-	zookeeperNodes, _ = kazoo.ParseConnectionString(*zkAddrs)
+	zookeeperNodes, chroot := kazoo.ParseConnectionString(*zkAddrs)
 
 	var kz *kazoo.Kazoo
-	if kz, err = kazoo.NewKazoo(zookeeperNodes, nil); err != nil {
+	conf := kazoo.NewConfig()
+	conf.Chroot = chroot
+	if kz, err = kazoo.NewKazoo(zookeeperNodes, conf); err != nil {
 		log.Error("%s", err)
 		return
 	}


### PR DESCRIPTION
Zookeeper connect strings have the concept of a "chroot" (http://zookeeper.apache.org/doc/trunk/zookeeperProgrammers.html#ch_zkSessions) to have more flexibility on the Kafka metadata location, which is heavily used in production installations. Kazoo already supports chroot natively; this change will propagate it through from this client.

Tested this on an existing setup.
