### PR TITLE
Fix bug in --use-tags

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func main() {
 						lag := tOffset - cgOffset
 
 						log.Info("Topic: %s, Partition: %d, Consumer Group: %s, Lag: %d", topic, partitionID, cg.Name, lag)
-						if useTags != nil {
+						if *useTags {
 							var tags []string
 							tags = append(tags, "topic="+topic)
 							tags = append(tags, fmt.Sprintf("partition=%d", partitionID))


### PR DESCRIPTION
Found a bug in `--use-tags` functionality. You are defaulting the `*bool` to `false` in the argument, but the logic that uses the argument checks for its existence (which will always be true due to having a default `false` value) rather than its actual boolean value.

Fix tested locally with some (removed) debug statements.